### PR TITLE
Fix two issues, Dependencies and Installation on different OS.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,19 +7,23 @@
 
 from __future__ import print_function
 
-from Cython.Build import cythonize
-from Cython.Distutils import build_ext
 from setuptools import Extension
 from setuptools import setup
+from distutils.command.build import build as _build
 
-import numpy as np
-
-
-# Obtain the numpy include directory.  This logic works across numpy versions.
-try:
-    numpy_include = np.get_include()
-except AttributeError:
-    numpy_include = np.get_numpy_include()
+# ref from https://stackoverflow.com/questions/54117786/add-numpy-get-include-argument-to-setuptools-without-preinstalled-numpy
+class build(_build):
+    def finalize_options(self):
+        super().finalize_options()
+        import builtins
+        builtins.__NUMPY_SETUP__ = False
+        import numpy as np
+        # Obtain the numpy include directory.  This logic works across numpy versions.
+        extension = next(m for m in self.distribution.ext_modules if m.name=='cython_bbox')
+        try:
+            extension.include_dirs.append(np.get_include())
+        except AttributeError:
+            extension.include_dirs.append(np.get_numpy_include())
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -29,13 +33,15 @@ ext_modules = [
         name='cython_bbox',
         sources=['src/cython_bbox.pyx'],
         extra_compile_args = {'gcc': ['/Qstd=c99']},
-        include_dirs=[numpy_include]
     )
 ]
 
 setup(
     name='cython_bbox',
-    ext_modules=cythonize(ext_modules),
+    setup_requires=["setuptools>=18.0","Cython","numpy"],
+    install_requires=["Cython","numpy"],
+    ext_modules=ext_modules,
+    cmdclass={'build': build},
     version = '0.1.3',
     description = 'Standalone cython_bbox',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 from setuptools import Extension
 from setuptools import setup
 from distutils.command.build import build as _build
+import os
 
 # ref from https://stackoverflow.com/questions/54117786/add-numpy-get-include-argument-to-setuptools-without-preinstalled-numpy
 class build(_build):
@@ -28,11 +29,16 @@ class build(_build):
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+if os.name == 'nt':
+    compile_args = {'gcc': ['/Qstd=c99']}
+else:
+    compile_args = ['-Wno-cpp']
+
 ext_modules = [
     Extension(
         name='cython_bbox',
         sources=['src/cython_bbox.pyx'],
-        extra_compile_args = {'gcc': ['/Qstd=c99']},
+        extra_compile_args = compile_args,
     )
 ]
 


### PR DESCRIPTION
1. b16bc75 Move non-built-in packages that were imported during the setup stage to other stages. This will solve the installation dependency issue when this repository is included in requirements.txt.
2. 9badb34 Use os.name to detect the Windows or Other during installation. And separate the values required for extra_compile_args under different OS. This solves both issues #4 and #3.