### PR TITLE
Replace np.float with float to be compatible with numpy==1.24.0

### DIFF
--- a/src/cython_bbox.pyx
+++ b/src/cython_bbox.pyx
@@ -9,8 +9,8 @@ cimport cython
 import numpy as np
 cimport numpy as np
 
-DTYPE = np.float
-ctypedef np.float_t DTYPE_t
+DTYPE = float
+ctypedef float DTYPE_t
 
 def bbox_overlaps(
         np.ndarray[DTYPE_t, ndim=2] boxes,


### PR DESCRIPTION
np.float was removed in numpy==1.24.0

https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations