### PR TITLE
np.float -> np.float64

### DIFF
--- a/src/cython_bbox.pyx
+++ b/src/cython_bbox.pyx
@@ -9,7 +9,7 @@ cimport cython
 import numpy as np
 cimport numpy as np
 
-DTYPE = np.float
+DTYPE = np.float64
 ctypedef np.float_t DTYPE_t
 
 def bbox_overlaps(


### PR DESCRIPTION
From __numpy1.24__, np.float is deprecated.
__np.float__ should be changed to __np.float64__