### PR TITLE
Update cython_bbox.pyx

### DIFF
--- a/src/cython_bbox.pyx
+++ b/src/cython_bbox.pyx
@@ -9,7 +9,7 @@ cimport cython
 import numpy as np
 cimport numpy as np
 
-DTYPE = np.float
+DTYPE = np.float64
 ctypedef np.float_t DTYPE_t
 
 def bbox_overlaps(


### PR DESCRIPTION
with numpy version >=1.20 the np.float is changed to np.float64 which cause error while using the cython_bbox package. So i have fixed it. 