### PR TITLE
Add support for Numpy >= 1.20

### DIFF
--- a/src/cython_bbox.pyx
+++ b/src/cython_bbox.pyx
@@ -9,7 +9,7 @@ cimport cython
 import numpy as np
 cimport numpy as np
 
-DTYPE = float
+DTYPE = np.float64
 ctypedef np.float64_t DTYPE_t
 
 __version__ = "0.1.5"
@@ -48,7 +48,7 @@ def bbox_overlaps(
                     max(boxes[n, 1], query_boxes[k, 1]) + 1
                 )
                 if ih > 0:
-                    ua = float(
+                    ua = DTYPE(
                         (boxes[n, 2] - boxes[n, 0] + 1) *
                         (boxes[n, 3] - boxes[n, 1] + 1) +
                         box_area - iw * ih


### PR DESCRIPTION
Starting from v1.20 Numpy has removed the float aliases, meaning that np.float does not automatically alias to anything. Since then, the specific float precision must be specified. This change simply replaces the alias for the 64bit float.